### PR TITLE
fix: added polling

### DIFF
--- a/.github/workflows/app-deploy.yaml
+++ b/.github/workflows/app-deploy.yaml
@@ -90,6 +90,21 @@ jobs:
           REPOSITORY: ${{ matrix.ecr_repository }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
+          # ECRはpush後に非同期でスキャンを登録するため、直後に describe するとScanNotFoundException になることがある。aws ecr wait image-scan-complete の
+          # waiterはこの例外をリトライ対象として扱わず即座に失敗するため、スキャンが登録されるまで先に手動でポーリングする。
+          echo "Waiting for image scan to be registered..."
+          for i in $(seq 1 30); do
+            if aws ecr describe-image-scan-findings \
+              --repository-name "$REPOSITORY" \
+              --image-id "imageTag=$IMAGE_TAG" \
+              --region "${{ vars.AWS_REGION }}" \
+              --query 'imageScanStatus.status' --output text >/dev/null 2>&1; then
+              break
+            fi
+            echo "Scan not registered yet... ($i/30)"
+            sleep 5
+          done
+
           echo "Waiting for image scan to complete..."
           aws ecr wait image-scan-complete \
             --repository-name "$REPOSITORY" \


### PR DESCRIPTION
## :link:チケット/Issue

<!-- 関連するチケットまたはIssueのリンク -->

## :memo:変更の目的/背景

<!-- なぜこの変更が必要なのか？（チケットやIssueに書かれている場合は省略可） -->
ECRはpush後に非同期でスキャンを登録するため、pushの直後にaws ecr wait image-scan-completeを呼ぶと「スキャンレコードがまだ存在しない」タイミングに当たることがあり、その場合botocoreはこの例外をリトライ対象と認識できず即座に失敗する。
ワークフロー側で事前ポーリングを入れて回避する。

## :hammer:変更内容

<!-- このPull Requestで何をしたのか？ -->
<!-- このPull Requestでやらないことは何か？（あれば。無いなら「無し」でOK。やらない場合は、いつやるのかを明記する。） -->

## :white_check_mark:動作確認

<!-- どのような動作確認を行ったのか？結果はどうか？（またはテストのリンクを貼る） -->

## :information_source:その他

<!-- レビュアーへの参考情報（実装上の懸念点や注意点、補足などあれば記載） -->